### PR TITLE
add close connection to avoid thousands of conns open

### DIFF
--- a/pkg/agent/influxmonitor.go
+++ b/pkg/agent/influxmonitor.go
@@ -72,6 +72,7 @@ func (im *InfluxMonitor) InitPing() (client.Client, time.Duration, string, error
 	}
 
 	response, err4 := con.Query(q)
+	con.Close()
 	if err4 == nil && response.Error() == nil {
 		log.Tracef("SHOW DATABASES On InitPint: %+v", response.Results)
 		im.lastcli = con


### PR DESCRIPTION
I have noticed too many connections open and I found that the ping test was not closing the connections. 